### PR TITLE
добавит обработку default interface

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,6 +48,11 @@ export class Compiler {
 
   private getName(id: ts.Node): string {
     const symbol = this.checker.getSymbolAtLocation(id);
+
+    if (symbol?.escapedName === "default") {
+      return symbol.parent.getName().slice(1, -1);
+    }
+    
     return symbol ? symbol.getName() : "unknown";
   }
 


### PR DESCRIPTION
при компиляции, оно ест поставляемые не знаю кем символы.
и символ InterfaceDeclaration срабатывает целиком на default interface
если слова default нет, то в методе getName поставляеися символ, чьим именем будет название интерфейса.
вот ткоа если дефолт есть, в имени будет тупа default.
разницы между двумя символами с дефолт и без НЕТ. нельзя определить по полям и прочему, что перед тобой. тока смотреть на escapedName.
и если символ дефолт, то уже в родителе будет нейм интерфейса. вот тока такое дело, что оно будет в кавычках, так что их нужно снять.
воооот.