### PR TITLE
ещё раз починить дефолтный экспорт

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,11 +48,6 @@ export class Compiler {
 
   private getName(id: ts.Node): string {
     const symbol = this.checker.getSymbolAtLocation(id);
-
-    if (symbol?.escapedName === "default") {
-      return symbol.parent.getName().slice(1, -1);
-    }
-    
     return symbol ? symbol.getName() : "unknown";
   }
 
@@ -201,7 +196,7 @@ export class Compiler {
     return this._formatExport(name, `t.enumtype({\n${members.join("")}})`);
   }
   private _compileInterfaceDeclaration(node: ts.InterfaceDeclaration): string {
-    const name = this.getName(node.name);
+    const name = node.name.escapedText.toString();
     const members = node.members
       .map(n => this.compileNode(n))
       .filter(n => n !== ignoreNode)


### PR DESCRIPTION
ладно, я повникал ещё больше. в перенте путь до файла ваще лежит, а не название интерфейса.
когда вызывается getname в _compileInterfaceDeclaration, оно передаёт поле name. которое Identifier и ващето в ескейпед тексте хранит имя интерфейса. но на месте оно превращается в символ по месту, который уже дефолт, лол. чесно говоря я не знаю, зачем изначально нужно ходить по всем стейтментам, а не просто взять експорт из ноды файла, как это тут сделано https://stackoverflow.com/questions/58886590/typescript-compiler-how-to-navigate-to-the-definition-of-a-symbol
но я не буду переписывать чужой проект целиком, потому что я ваще в приклюение на 5 минут отправился, что мне дефолтные экспорты не нужно было переписывать в неймед.
короче. просто вместое getname буду брать escapedText, и да поможет мне бог.
это мне на будущее, если будет нех делать https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#using-the-type-checker